### PR TITLE
General improvements and fixes to the Margin Tool and file parsing.

### DIFF
--- a/REvernus/ViewModels/MarginToolViewModel.cs
+++ b/REvernus/ViewModels/MarginToolViewModel.cs
@@ -273,7 +273,7 @@ namespace REvernus.ViewModels
             // various other fields do not get populated with the correct data.
             // Sleeping the thread seems to fix the problem
             
-            System.Threading.Thread.Sleep(5);
+            System.Threading.Thread.Sleep(50);
             
             try
             {
@@ -285,7 +285,7 @@ namespace REvernus.ViewModels
                     {
                         try
                         {
-                            var firstline = reader.ReadLine().Split(','); // read first line and disregard
+                            reader.ReadLine(); // read first line and disregard
                             while (!reader.EndOfStream)
                             {
                             

--- a/REvernus/ViewModels/MarginToolViewModel.cs
+++ b/REvernus/ViewModels/MarginToolViewModel.cs
@@ -281,16 +281,13 @@ namespace REvernus.ViewModels
                 {
                     using (var reader = new StreamReader(file))
                     {
-                        int lineCounter = 0;
-                        while (!reader.EndOfStream)
+                        try
                         {
-                            try
+                            var firstline = reader.ReadLine().Split(','); // read first line and disregard
+                            while (!reader.EndOfStream)
                             {
-                                
-                                var values = reader.ReadLine().Split(',');
-                                lineCounter++;
-                                if (lineCounter > 1) // Do not parse the 1st line of the file
-                                {
+                            
+                                    var values = reader.ReadLine().Split(',');
                                     var order = new ExportedOrderModel();
                                     order.Price = double.Parse(values[0], CultureInfo.InvariantCulture);
                                     order.VolumeRemaining = Convert.ToInt32(Math.Floor(Convert.ToDouble(values[1])), CultureInfo.InvariantCulture);
@@ -308,12 +305,12 @@ namespace REvernus.ViewModels
                                     order.NumJumpsAway = int.Parse(values[13], CultureInfo.InvariantCulture);
 
                                     Orders.Add(order);
-                                }
+                           
                             }
-                            catch (Exception)
-                            {
-                                // ignored
-                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            // ignored
                         }
                     }
                 }

--- a/REvernus/ViewModels/MarginToolViewModel.cs
+++ b/REvernus/ViewModels/MarginToolViewModel.cs
@@ -272,7 +272,7 @@ namespace REvernus.ViewModels
             // There appears to be some sort of timing error resulting in NaN in the window under Margin and Markup
             // various other fields do not get populated with the correct data.
             // Sleeping the thread seems to fix the problem
-            System.Threading.Thread.Sleep(5);
+            System.Threading.Thread.Sleep(50);
             try
             {
                 var currentChar = CharacterManager.SelectedCharacter;
@@ -281,29 +281,34 @@ namespace REvernus.ViewModels
                 {
                     using (var reader = new StreamReader(file))
                     {
-
+                        int lineCounter = 0;
                         while (!reader.EndOfStream)
                         {
                             try
                             {
+                                
                                 var values = reader.ReadLine().Split(',');
-                                var order = new ExportedOrderModel();
-                                order.Price = double.Parse(values[0], CultureInfo.InvariantCulture);
-                                order.VolumeRemaining = Convert.ToInt32(Math.Floor(Convert.ToDouble(values[1])), CultureInfo.InvariantCulture);
-                                order.TypeId = int.Parse(values[2], CultureInfo.InvariantCulture);
-                                order.Range = int.Parse(values[3], CultureInfo.InvariantCulture);
-                                order.OrderId = long.Parse(values[4], CultureInfo.InvariantCulture);
-                                order.VolumeEntered = int.Parse(values[5], CultureInfo.InvariantCulture);
-                                order.MinVolume = int.Parse(values[6], CultureInfo.InvariantCulture);
-                                order.IsBuyOrder = bool.Parse(values[7]);
-                                order.DateIssued = DateTime.Parse(values[8], CultureInfo.InvariantCulture);
-                                order.Duration = int.Parse(values[9], CultureInfo.InvariantCulture);
-                                order.StationId = long.Parse(values[10], CultureInfo.InvariantCulture);
-                                order.RegionId = int.Parse(values[11], CultureInfo.InvariantCulture);
-                                order.SystemId = int.Parse(values[12], CultureInfo.InvariantCulture);
-                                order.NumJumpsAway = int.Parse(values[13], CultureInfo.InvariantCulture);
+                                lineCounter++;
+                                if (lineCounter > 1) // Do not parse the 1st line of the file
+                                {
+                                    var order = new ExportedOrderModel();
+                                    order.Price = double.Parse(values[0], CultureInfo.InvariantCulture);
+                                    order.VolumeRemaining = Convert.ToInt32(Math.Floor(Convert.ToDouble(values[1])), CultureInfo.InvariantCulture);
+                                    order.TypeId = int.Parse(values[2], CultureInfo.InvariantCulture);
+                                    order.Range = int.Parse(values[3], CultureInfo.InvariantCulture);
+                                    order.OrderId = long.Parse(values[4], CultureInfo.InvariantCulture);
+                                    order.VolumeEntered = int.Parse(values[5], CultureInfo.InvariantCulture);
+                                    order.MinVolume = int.Parse(values[6], CultureInfo.InvariantCulture);
+                                    order.IsBuyOrder = bool.Parse(values[7]);
+                                    order.DateIssued = DateTime.Parse(values[8], CultureInfo.InvariantCulture);
+                                    order.Duration = int.Parse(values[9], CultureInfo.InvariantCulture);
+                                    order.StationId = long.Parse(values[10], CultureInfo.InvariantCulture);
+                                    order.RegionId = int.Parse(values[11], CultureInfo.InvariantCulture);
+                                    order.SystemId = int.Parse(values[12], CultureInfo.InvariantCulture);
+                                    order.NumJumpsAway = int.Parse(values[13], CultureInfo.InvariantCulture);
 
-                                Orders.Add(order);
+                                    Orders.Add(order);
+                                }
                             }
                             catch (Exception)
                             {

--- a/REvernus/ViewModels/MarginToolViewModel.cs
+++ b/REvernus/ViewModels/MarginToolViewModel.cs
@@ -273,7 +273,7 @@ namespace REvernus.ViewModels
             // various other fields do not get populated with the correct data.
             // Sleeping the thread seems to fix the problem
             
-            System.Threading.Thread.Sleep(50);
+            System.Threading.Thread.Sleep(5);
             
             try
             {

--- a/REvernus/ViewModels/MarginToolViewModel.cs
+++ b/REvernus/ViewModels/MarginToolViewModel.cs
@@ -446,7 +446,7 @@ namespace REvernus.ViewModels
             try
             {
                 if (Application.Current.Dispatcher != null)
-                    Application.Current.Dispatcher.Invoke(() => Clipboard.SetText(BuyCopyPrice));
+                    Application.Current.Dispatcher.Invoke(() => Clipboard.SetDataObject(BuyCopyPrice));   
             }
             catch (Exception e)
             {
@@ -460,7 +460,7 @@ namespace REvernus.ViewModels
             try
             {
                 if (Application.Current.Dispatcher != null)
-                    Application.Current.Dispatcher.Invoke(() => Clipboard.SetText(SellCopyPrice));
+                    Application.Current.Dispatcher.Invoke(() => Clipboard.SetDataObject(SellCopyPrice));
             }
             catch (Exception e)
             {

--- a/REvernus/ViewModels/MarginToolViewModel.cs
+++ b/REvernus/ViewModels/MarginToolViewModel.cs
@@ -269,6 +269,10 @@ namespace REvernus.ViewModels
 
         private void WatcherOnChanged(object sender, FileSystemEventArgs e)
         {
+            // There appears to be some sort of timing error resulting in NaN in the window under Margin and Markup
+            // various other fields do not get populated with the correct data.
+            // Sleeping the thread seems to fix the problem
+            System.Threading.Thread.Sleep(5);
             try
             {
                 var currentChar = CharacterManager.SelectedCharacter;


### PR DESCRIPTION
Added some code to skip parsing of the first line of the exported market file.
This keeps the exception from firing due to text not being in proper format.

There are merge conflicts that I don't know how to address